### PR TITLE
Nested entities

### DIFF
--- a/src/utils/process_entity.ts
+++ b/src/utils/process_entity.ts
@@ -30,35 +30,38 @@ export function processEntity(
     text: entityText,
   });
 
-  // Check if the next entity starts at the same position as the current one (nested entity).
-  if (entity.offset === nextEntity?.offset) {
-    // Recursively process the next entity.
-    const { text: htmlText, index: lastIndex, endOfEntity } = processEntity({
+  // Process nested or overlapping entities
+  let nestedText = "";
+  let currentIndex = index + 1;
+
+  while (
+    currentIndex < entities.length &&
+    entities[currentIndex].offset < entity.offset + entity.length
+  ) {
+    const nestedEntityResult = processEntity({
       ...options,
-      index: index + 1,
+      index: currentIndex,
     });
 
-    const remainingText = text.slice(
-      endOfEntity,
-      entity.offset + entity.length,
-    );
-
-    const escapedText = textSanitizer({ text: remainingText });
-
-    return {
-      index: lastIndex,
-      text: `${prefix}${htmlText}${escapedText}${suffix}`,
-      endOfEntity: entity.offset + entity.length,
-    };
-  } else {
-    const escapedText = textSanitizer({ text: entityText });
-
-    return {
-      index,
-      text: `${prefix}${escapedText}${suffix}`,
-      endOfEntity: entity.offset + entity.length,
-    };
+    nestedText += nestedEntityResult.text;
+    currentIndex = nestedEntityResult.index + 1;
   }
+
+  // Compute the remaining text after nested entities
+  const remainingText = text.slice(
+    nestedText
+      ? Math.max(...entities.map((e) => e.offset + e.length))
+      : entity.offset + entity.length,
+    entity.offset + entity.length,
+  );
+
+  const escapedText = textSanitizer({ text: remainingText });
+
+  return {
+    index: currentIndex - 1,
+    text: `${prefix}${nestedText || escapedText}${suffix}`,
+    endOfEntity: entity.offset + entity.length,
+  };
 }
 
 interface ProcessEntityOption {


### PR DESCRIPTION
Currently I'm facing an issue where nested entities, such as bold, italics etc. inside blockquotes, get discarded or do not render correctly.
I'm willing to fix the issue and I'll update this PR to get ready to be merged.


## Test case (by Alessandro in grammY telegram group):

```typescript
Deno.test("Should deal with nested entities", () => {
  const text = `boldItalic`;
  const entities: MessageEntity[] = [
    {
      offset: 0,
      length: 10,
      type: "blockquote",
    },
    {
      offset: 0,
      length: 4,
      type: "bold",
    },
    {
      offset: 4,
      length: 6,
      type: "bold",
    },
    {
      offset: 4,
      length: 6,
      type: "italic",
    },
  ];
  const entitiesParser = new EntitiesParser();
  const parse = (message: Message) => entitiesParser.parse({ message });
  const html = parse({ text, entities });

  assertEquals(
    html,
    '<blockquote class="tg-blockquote"><b class="tg-bold">bold</b><b class="tg-bold"><i class="tg-italic">Italic</i></b></blockquote>'
  );
});
```

### // result

```html
-   <blockquote class="tg-blockquote"><b class="tg-bold">bold</b>Italic</blockquote><b class="tg-bold"><i class="tg-italic">Italic</i></b>
+   <blockquote class="tg-blockquote"><b class="tg-bold">bold</b><b class="tg-bold"><i class="tg-italic">Italic</i></b></blockquote>
```